### PR TITLE
add component task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -276,10 +276,30 @@ module.exports = function(grunt) {
         "bower.json",
         "composer.json"
       ]
+    },
+    "regex-replace": {
+      // disable image fonts in default HTML-CSS config
+      noImageFont: {
+        src: ['unpacked/jax/output/HTML-CSS/config.js'],
+        actions: [
+          {
+            name: 'nullImageFont',
+            search: /imageFont:[^,]+,/,
+            replace: 'imageFont: null,',
+          }
+        ]
+      }
     }
   });
 
   grunt.loadNpmTasks("grunt-contrib-clean");
+  grunt.loadNpmTasks('grunt-regex-replace');
+
+  grunt.registerTask("component", [
+    // components-mathjax excludes only PNG fonts
+    "regex-replace:noImageFont",
+    "clean:png",
+  ]);
 
   grunt.registerTask("template", [
     // **Notes** on the template. When instructions say "Pick one", this means commenting out one item (so that it"s not cleaned).

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
+    "grunt-regex-replace": "^0.2.6",
     "matchdep": "*"
   }
 }


### PR DESCRIPTION
implements mathjax/MathJax#1214
- removes png image fonts
- disables imageFont in HTML-CSS config via regex

The regex is extremely primitive, but works. It will start to fail if:
- `imageFont:` starts showing up in more than one place
- The `imageFont:` line loses its trailing comma
